### PR TITLE
feat: Paths — beginner-friendly shipping companion UI

### DIFF
--- a/.agents/skills/tailscale-preview/SKILL.md
+++ b/.agents/skills/tailscale-preview/SKILL.md
@@ -1,0 +1,46 @@
+# Tailscale Preview — serve the app for remote browser access
+
+Run the Pipelab UI + CLI dev servers so a remote browser (e.g. the developer's
+laptop) can open the UI over Tailscale. Use when asked to "start the app",
+"preview from tailscale", or expose a dev URL.
+
+## Procedure
+
+1. Confirm Tailscale is up: `tailscale ip -4`. Note the machine IP
+   (e.g. `100.111.167.123`). The UI URL is `http://<ip>:5173`.
+2. Launch both servers **detached** (stdin from `/dev/null`, own session —
+   never plain `&` from a terminal, see Gotchas):
+   - CLI: `setsid bash -c 'pnpm --filter @pipelab/cli dev > /tmp/pipelab-cli.log 2>&1 < /dev/null' &`
+   - UI: `setsid bash -c 'pnpm --filter @pipelab/ui exec vite --host 0.0.0.0 --port 5173 > /tmp/pipelab-ui.log 2>&1 < /dev/null' &`
+   - `disown -a` afterwards if launched from an interactive shell.
+3. Wait ~30s. Verify in order:
+   - CLI log shows `WebSocket server listening on port 33753` and
+     `[Startup Progress] Ready!`: `grep -E 'listening on port|Ready!' /tmp/pipelab-cli.log`
+   - CLI process is **not** in `T (stopped)` state:
+     `cat /proc/$(pgrep -f 'tsx/dist/loader' | head -1)/status | grep State`
+     (must read `S`, never `T`).
+   - WebSocket handshake succeeds over the Tailscale IP:
+     `node -e "new (require('<repo>/node_modules/ws'))('ws://<ip>:33753').on('open', () => { console.log('WS-OK'); process.exit(0); })"`
+   - UI serves 200 over the Tailscale IP:
+     `curl -o /dev/null -w "%{http_code}\n" http://<ip>:5173/paths`
+4. Hand the user `http://<ip>:5173`. Tell them to **hard-refresh** if the
+   bundle changed since their last visit.
+5. The user confirming the page loads past "initializing environment" is the
+   done gate. The UI stays connected via WebSocket; "initializing
+   environment" stuck = the browser can't reach the CLI server.
+
+## Gotchas (learned the hard way)
+
+- **Suspended process**: launching with plain `&` from a terminal leaves the
+  process group attached; the kernel SIGSTOPs it (`State: T`,
+  `wchan: do_signal_stop`) on terminal I/O and connections pile up in the
+  listen backlog (`ss -tln` shows Recv-Q > 0) with zero CPU. Always `setsid`
+  + `< /dev/null`. If stuck: `kill -9` the pipeline and relaunch detached.
+- **Localhost-only defaults**: the CLI WebSocket server must bind `0.0.0.0`
+  (`packages/core-node/src/websocket-server.ts`) and the UI dev client must
+  connect to `window.location.hostname`, not `localhost`
+  (`apps/ui/src/composables/websocket-client.ts`). Both fixes are in the
+  codebase; if remote init hangs, re-check these two lines first.
+- **Vite needs `--host 0.0.0.0`** or the dev server only listens on loopback.
+- Port `33753` is the CLI WebSocket/API port (`@pipelab/constants`
+  `websocketPort`); UI dev port is `5173`.

--- a/.changeset/bold-paths-ship.md
+++ b/.changeset/bold-paths-ship.md
@@ -1,0 +1,17 @@
+---
+"@pipelab/ui": minor
+"@pipelab/shared": minor
+---
+
+feat: add Paths — a beginner-friendly shipping companion UI
+
+Replace the dead simple-editor with a new Path Builder screen:
+- Source card at the top (engine type + folder + last export)
+- Per-destination rows with delivery selector (App/Web/Archive) and Ship button
+- Add/remove destinations via inline sheets, no navigation
+- Credentials inline on first use, keychain-referenced
+- Ship All button for parallel shipping
+- Destination states: ready, shipping (progress), shipped (timestamp), failed (retry/skip), skipped
+
+New path data model in shared (Source, Destination, Path, RunState types).
+Old plugin-based pipeline remains functional; Paths is a parallel entry point.

--- a/apps/ui/src/components/Layout.vue
+++ b/apps/ui/src/components/Layout.vue
@@ -41,6 +41,16 @@
           </span>
         </router-link>
 
+        <router-link
+          to="/paths"
+          class="sidebar-nav-item"
+          active-class="active"
+          v-tooltip.right="isSidebarCollapsed ? 'Paths' : undefined"
+        >
+          <i class="mdi mdi-routes nav-icon" />
+          <span v-show="!isSidebarCollapsed" class="nav-label">Paths</span>
+        </router-link>
+
         <div
           class="sidebar-nav-item disabled"
           v-tooltip.right="isSidebarCollapsed ? 'Connections (Coming Soon)' : 'Coming Soon'"

--- a/apps/ui/src/components/paths/AddDestinationSheet.vue
+++ b/apps/ui/src/components/paths/AddDestinationSheet.vue
@@ -1,0 +1,108 @@
+<template>
+  <div class="add-backdrop" @click.self="$emit('close')">
+    <div class="add-sheet">
+      <h3 class="sheet-title">Add destination</h3>
+      <div class="platform-grid">
+        <button
+          v-for="opt in availableOptions"
+          :key="opt.value"
+          class="platform-option"
+          @click="$emit('pick', opt.value)"
+        >
+          <i class="mdi platform-icon" :class="opt.icon" :style="{ color: opt.color }"></i>
+          <span class="platform-name">{{ opt.name }}</span>
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import type { DestinationType } from "@pipelab/shared";
+
+const props = defineProps<{ usedTypes: DestinationType[] }>();
+
+defineEmits<{
+  (e: "pick", type: DestinationType): void;
+  (e: "close"): void;
+}>();
+
+const ALL_OPTIONS: { value: DestinationType; name: string; icon: string; color: string }[] = [
+  { value: "steam", name: "Steam", icon: "mdi-steam", color: "#1b2838" },
+  { value: "itch", name: "Itch.io", icon: "mdi-puzzle", color: "#fa5c5c" },
+  { value: "poki", name: "Poki", icon: "mdi-gamepad-variant", color: "#0096ff" },
+  { value: "discord-activity", name: "Discord", icon: "mdi-discord", color: "#5865f2" },
+  { value: "netlify", name: "Netlify", icon: "mdi-cloud", color: "#00c7b7" },
+  { value: "web", name: "Web", icon: "mdi-web", color: "#22c55e" },
+  { value: "folder", name: "Folder", icon: "mdi-folder", color: "#8b8b96" },
+];
+
+const availableOptions = computed(() =>
+  ALL_OPTIONS.filter((o) => !props.usedTypes.includes(o.value)),
+);
+</script>
+
+<style scoped>
+.add-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 80px;
+  z-index: 1000;
+}
+
+.add-sheet {
+  background: #18181c;
+  border: 1px solid #2a2a30;
+  border-radius: 8px;
+  padding: 24px;
+  width: 480px;
+  max-width: 90vw;
+}
+
+.sheet-title {
+  font-size: 16px;
+  font-weight: 500;
+  color: #e4e4e7;
+  margin: 0 0 16px;
+}
+
+.platform-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+}
+
+.platform-option {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 20px 8px;
+  background: #1e1e24;
+  border: 1px solid #2a2a30;
+  border-radius: 8px;
+  color: #e4e4e7;
+  font-size: 12px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.platform-option:hover {
+  background: #2a2a30;
+  border-color: #3a3a42;
+}
+
+.platform-icon {
+  font-size: 24px;
+}
+
+.platform-name {
+  font-size: 12px;
+  color: #e4e4e7;
+}
+</style>

--- a/apps/ui/src/components/paths/DestinationRow.vue
+++ b/apps/ui/src/components/paths/DestinationRow.vue
@@ -8,7 +8,7 @@
       <i class="mdi platform-icon" :class="meta.icon" :style="{ color: meta.color }"></i>
       <div class="platform-text">
         <span class="platform-name">{{ meta.name }}</span>
-        <span class="platform-delivery" :class="deliveryTextClass">
+        <span class="platform-delivery" :class="{ failed: state?.state === 'failed' }">
           {{ deliveryText }}
         </span>
       </div>
@@ -49,7 +49,7 @@
           :key="opt"
           class="seg"
           :class="{ active: destination.delivery === opt }"
-          :disabled="opt !== destination.delivery && !isDeliveryValid(opt)"
+          :disabled="opt !== destination.delivery && !validDeliveries.includes(opt)"
           @click="$emit('update-delivery', opt)"
         >
           {{ opt }}
@@ -113,7 +113,6 @@ import type { Destination, DeliveryKind, DestinationRun } from "@pipelab/shared"
 const props = defineProps<{
   destination: Destination;
   state?: DestinationRun;
-  credentialSaving: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -153,8 +152,6 @@ const validDeliveries = computed<DeliveryKind[]>(
   () => DELIVERY_OPTIONS[props.destination.type] ?? [],
 );
 
-const isDeliveryValid = (d: DeliveryKind) => validDeliveries.value.includes(d);
-
 const needsCredentials = computed(() => {
   const t = props.destination.type;
   return t === "steam" || t === "itch" || t === "poki" || t === "discord-activity" || t === "netlify";
@@ -168,11 +165,6 @@ const hasCredential = computed(() => {
 const deliveryText = computed(() => {
   const d = props.destination.delivery;
   return d.charAt(0).toUpperCase() + d.slice(1);
-});
-
-const deliveryTextClass = computed(() => {
-  if (props.state?.state === "failed") return "failed";
-  return "";
 });
 
 const rowClass = computed(() => {

--- a/apps/ui/src/components/paths/DestinationRow.vue
+++ b/apps/ui/src/components/paths/DestinationRow.vue
@@ -1,0 +1,589 @@
+<template>
+  <div class="dest-row" :class="rowClass">
+    <!-- Zone 1: Platform -->
+    <div class="zone-platform">
+      <button class="remove-btn" @click="$emit('remove')" aria-label="Remove destination">
+        <i class="mdi mdi-close"></i>
+      </button>
+      <i class="mdi platform-icon" :class="meta.icon" :style="{ color: meta.color }"></i>
+      <div class="platform-text">
+        <span class="platform-name">{{ meta.name }}</span>
+        <span class="platform-delivery" :class="deliveryTextClass">
+          {{ deliveryText }}
+        </span>
+      </div>
+    </div>
+
+    <!-- Zone 2: Center (logs, credentials) -->
+    <div class="zone-center">
+      <!-- Credentials missing warning -->
+      <div v-if="needsCredentials && !hasCredential" class="cred-warning">
+        <i class="mdi mdi-key-alert"></i>
+        <input
+          v-model="credentialInput"
+          type="text"
+          class="cred-input"
+          :placeholder="meta.credentialPlaceholder"
+        />
+        <button class="cred-save-btn" @click="saveCredential">Save</button>
+      </div>
+
+      <!-- Shipping progress -->
+      <div v-else-if="state?.state === 'shipping'" class="progress-wrap">
+        <div class="progress-bar"><div class="progress-fill"></div></div>
+        <span class="log-line">{{ state.lastLog || "Starting…" }}</span>
+      </div>
+
+      <!-- Error state -->
+      <div v-else-if="state?.state === 'failed'" class="error-logs">
+        <span v-for="(line, i) in errorLines" :key="i" class="error-line">{{ line }}</span>
+      </div>
+    </div>
+
+    <!-- Zone 3: Right (delivery selector + ship) -->
+    <div class="zone-right">
+      <!-- Delivery selector -->
+      <div class="delivery-selector">
+        <button
+          v-for="opt in validDeliveries"
+          :key="opt"
+          class="seg"
+          :class="{ active: destination.delivery === opt }"
+          :disabled="opt !== destination.delivery && !isDeliveryValid(opt)"
+          @click="$emit('update-delivery', opt)"
+        >
+          {{ opt }}
+        </button>
+      </div>
+
+      <!-- Ship button -->
+      <button
+        v-if="state?.state === 'failed'"
+        class="ship-btn retry"
+        @click="$emit('retry')"
+      >
+        <i class="mdi mdi-refresh"></i>
+        Retry
+      </button>
+      <button
+        v-else-if="state?.state === 'shipping'"
+        class="ship-btn shipping"
+        disabled
+      >
+        <i class="mdi mdi-loading mdi-spin"></i>
+        Shipping…
+      </button>
+      <button
+        v-else-if="state?.state === 'skipped'"
+        class="ship-btn resume"
+        @click="$emit('ship')"
+      >
+        Resume
+      </button>
+      <button
+        v-else-if="state?.state === 'shipped'"
+        class="ship-btn shipped"
+        @click="$emit('ship')"
+      >
+        Shipped {{ shippedAgo }}
+      </button>
+      <button
+        v-else-if="needsCredentials && !hasCredential"
+        class="ship-btn muted"
+        disabled
+      >
+        Set up credentials
+      </button>
+      <button
+        v-else
+        class="ship-btn primary"
+        :disabled="!isReadyToShip"
+        @click="$emit('ship')"
+      >
+        Ship
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import type { Destination, DeliveryKind, DestinationRun } from "@pipelab/shared";
+
+const props = defineProps<{
+  destination: Destination;
+  state?: DestinationRun;
+  credentialSaving: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: "update-delivery", d: DeliveryKind): void;
+  (e: "remove"): void;
+  (e: "ship"): void;
+  (e: "retry"): void;
+  (e: "skip"): void;
+  (e: "save-credential", credentialId: string): void;
+}>();
+
+const credentialInput = ref("");
+
+const DEST_META: Record<string, { name: string; icon: string; color: string; credentialPlaceholder: string }> = {
+  steam: { name: "Steam", icon: "mdi-steam", color: "#1b2838", credentialPlaceholder: "Steam API key" },
+  itch: { name: "Itch.io", icon: "mdi-puzzle", color: "#fa5c5c", credentialPlaceholder: "Itch API key" },
+  poki: { name: "Poki", icon: "mdi-gamepad-variant", color: "#0096ff", credentialPlaceholder: "Poki API key" },
+  "discord-activity": { name: "Discord", icon: "mdi-discord", color: "#5865f2", credentialPlaceholder: "Discord App ID" },
+  netlify: { name: "Netlify", icon: "mdi-cloud", color: "#00c7b7", credentialPlaceholder: "Netlify token" },
+  web: { name: "Web", icon: "mdi-web", color: "#22c55e", credentialPlaceholder: "" },
+  folder: { name: "Folder", icon: "mdi-folder", color: "#8b8b96", credentialPlaceholder: "" },
+};
+
+const DELIVERY_OPTIONS: Record<string, DeliveryKind[]> = {
+  steam: ["app"],
+  itch: ["app", "web", "archive"],
+  poki: ["web"],
+  "discord-activity": ["app"],
+  netlify: ["web"],
+  web: ["web"],
+  folder: ["app", "web", "archive"],
+};
+
+const meta = computed(() => DEST_META[props.destination.type] ?? DEST_META.folder);
+
+const validDeliveries = computed<DeliveryKind[]>(
+  () => DELIVERY_OPTIONS[props.destination.type] ?? [],
+);
+
+const isDeliveryValid = (d: DeliveryKind) => validDeliveries.value.includes(d);
+
+const needsCredentials = computed(() => {
+  const t = props.destination.type;
+  return t === "steam" || t === "itch" || t === "poki" || t === "discord-activity" || t === "netlify";
+});
+
+const hasCredential = computed(() => {
+  const c = (props.destination as any).credentialId;
+  return typeof c === "string" && c.length > 0;
+});
+
+const deliveryText = computed(() => {
+  const d = props.destination.delivery;
+  return d.charAt(0).toUpperCase() + d.slice(1);
+});
+
+const deliveryTextClass = computed(() => {
+  if (props.state?.state === "failed") return "failed";
+  return "";
+});
+
+const rowClass = computed(() => {
+  switch (props.state?.state) {
+    case "shipping":
+      return "shipping";
+    case "failed":
+      return "failed";
+    case "skipped":
+      return "skipped";
+    case "shipped":
+      return "shipped";
+    default:
+      return "";
+  }
+});
+
+const errorLines = computed(() => {
+  if (props.state?.error) {
+    return props.state.error.split("\n").slice(-3);
+  }
+  return ["Ship failed"];
+});
+
+const shippedAgo = computed(() => {
+  if (!props.state?.finishedAt) return "";
+  const seconds = Math.floor((Date.now() - props.state.finishedAt) / 1000);
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  return `${Math.floor(minutes / 60)}h ago`;
+});
+
+const isReadyToShip = computed(() => {
+  if (props.destination.type === "folder") {
+    return !!(props.destination as any).outputDir;
+  }
+  if (props.destination.type === "web") {
+    return !!(props.destination as any).outputDir;
+  }
+  if (needsCredentials.value) {
+    return hasCredential.value;
+  }
+  return true;
+});
+
+const saveCredential = () => {
+  if (!credentialInput.value) return;
+  emit("save-credential", credentialInput.value);
+  credentialInput.value = "";
+};
+</script>
+
+<style scoped>
+.dest-row {
+  display: flex;
+  align-items: stretch;
+  min-height: 72px;
+  padding: 12px 16px;
+  gap: 16px;
+  border-radius: 8px;
+  transition: background 0.3s;
+  position: relative;
+}
+
+.dest-row.shipping {
+  background: #1e1e24;
+}
+
+.dest-row.failed {
+  background: #1e1215;
+}
+
+.dest-row.skipped {
+  background: #1a1a1e;
+}
+
+.dest-row.shipped {
+  background: transparent;
+}
+
+/* ─── Zone 1: Platform ─────────────────────────────────────────────────── */
+
+.zone-platform {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 200px;
+  flex-shrink: 0;
+  position: relative;
+}
+
+.remove-btn {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  color: #8b8b96;
+  cursor: pointer;
+  border-radius: 4px;
+  opacity: 0;
+  transition: opacity 0.15s, color 0.15s, background 0.15s;
+  z-index: 2;
+}
+
+.dest-row:hover .remove-btn {
+  opacity: 1;
+}
+
+.remove-btn:hover {
+  background: rgba(239, 68, 68, 0.1);
+  color: #ef4444;
+}
+
+.remove-btn .mdi {
+  font-size: 14px;
+}
+
+.platform-icon {
+  font-size: 24px;
+  flex-shrink: 0;
+}
+
+.platform-text {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.platform-name {
+  font-size: 14px;
+  font-weight: 500;
+  color: #e4e4e7;
+  white-space: nowrap;
+}
+
+.dest-row.skipped .platform-name {
+  color: #8b8b96;
+}
+
+.platform-delivery {
+  font-size: 11px;
+  color: #8b8b96;
+  margin-top: 2px;
+}
+
+.platform-delivery.failed {
+  color: #ef4444;
+}
+
+/* ─── Zone 2: Center ───────────────────────────────────────────────────── */
+
+.zone-center {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-width: 0;
+  gap: 6px;
+}
+
+/* Credentials */
+
+.cred-warning {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.cred-warning .mdi {
+  color: #f59e0b;
+  font-size: 16px;
+  flex-shrink: 0;
+}
+
+.cred-input {
+  flex: 1;
+  padding: 6px 10px;
+  background: #1e1e24;
+  border: 1px solid #2a2a30;
+  border-radius: 4px;
+  color: #e4e4e7;
+  font-size: 12px;
+  font-family: monospace;
+  min-width: 0;
+}
+
+.cred-input:focus {
+  outline: none;
+  border-color: #6366f1;
+}
+
+.cred-save-btn {
+  padding: 6px 12px;
+  background: none;
+  border: 1px solid #2a2a30;
+  border-radius: 4px;
+  color: #8b8b96;
+  font-size: 12px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.cred-save-btn:hover {
+  color: #e4e4e7;
+  border-color: #3a3a42;
+}
+
+/* Progress */
+
+.progress-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.progress-bar {
+  height: 4px;
+  background: #3a3a42;
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  background: #6366f1;
+  width: 100%;
+  animation: indeterminate 1.4s linear infinite;
+  transform-origin: left;
+}
+
+@keyframes indeterminate {
+  0% {
+    transform: translateX(-100%) scaleX(0.5);
+  }
+  50% {
+    transform: translateX(0) scaleX(0.7);
+  }
+  100% {
+    transform: translateX(100%) scaleX(0.5);
+  }
+}
+
+.log-line {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 11px;
+  color: #8b8b96;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Errors */
+
+.error-logs {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.error-line {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 11px;
+  color: #ef4444;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ─── Zone 3: Right ────────────────────────────────────────────────────── */
+
+.zone-right {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 160px;
+  flex-shrink: 0;
+  align-items: stretch;
+}
+
+.delivery-selector {
+  display: flex;
+  gap: 2px;
+  height: 28px;
+}
+
+.seg {
+  flex: 1;
+  background: #1e1e24;
+  border: 1px solid #2a2a30;
+  color: #8b8b96;
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: capitalize;
+  cursor: pointer;
+  transition: all 0.15s;
+  border-radius: 0;
+}
+
+.seg:first-child {
+  border-radius: 4px 0 0 4px;
+}
+
+.seg:last-child {
+  border-radius: 0 4px 4px 0;
+}
+
+.seg:not(:first-child) {
+  border-left: none;
+}
+
+.seg:hover:not(:disabled) {
+  background: #2a2a30;
+  color: #e4e4e7;
+}
+
+.seg.active {
+  background: #2e2e36;
+  border-color: #3a3a42;
+  color: #e4e4e7;
+}
+
+.seg:disabled {
+  background: #1e1e24;
+  color: #3a3a42;
+  cursor: default;
+}
+
+/* Ship button */
+
+.ship-btn {
+  height: 36px;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  border: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  transition: all 0.15s;
+}
+
+.ship-btn.primary {
+  background: #22c55e;
+  color: white;
+}
+
+.ship-btn.primary:not(:disabled):hover {
+  background: #16a34a;
+}
+
+.ship-btn.primary:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.ship-btn.shipping {
+  background: #1e1e24;
+  color: #8b8b96;
+  cursor: default;
+}
+
+.ship-btn.retry {
+  background: #22c55e;
+  color: white;
+}
+
+.ship-btn.retry:hover {
+  background: #16a34a;
+}
+
+.ship-btn.shipped {
+  background: none;
+  color: #8b8b96;
+  font-weight: 400;
+}
+
+.ship-btn.shipped:hover {
+  color: #e4e4e7;
+}
+
+.ship-btn.skipped {
+  background: none;
+  color: #8b8b96;
+}
+
+.ship-btn.resume {
+  background: none;
+  color: #6366f1;
+}
+
+.ship-btn.resume:hover {
+  color: #818cf8;
+}
+
+.ship-btn.muted {
+  background: none;
+  color: #3a3a42;
+  cursor: not-allowed;
+}
+
+.ship-btn .mdi {
+  font-size: 14px;
+}
+</style>

--- a/apps/ui/src/components/paths/SourceCard.vue
+++ b/apps/ui/src/components/paths/SourceCard.vue
@@ -1,0 +1,149 @@
+<template>
+  <div class="source-card" :class="{ warning: sourceWarning }">
+    <i class="mdi engine-icon" :class="engineIcon"></i>
+    <div class="source-text">
+      <span class="engine-name">{{ engineLabel }}</span>
+      <span class="source-path">{{ pathDisplay }}</span>
+    </div>
+    <span class="last-export" v-if="lastExport">
+      Last export: {{ formatTimeAgo(lastExport) }}
+    </span>
+    <span class="warning-text" v-else-if="sourceWarning">
+      Source changed
+    </span>
+    <button class="edit-btn" @click="$emit('edit')" aria-label="Edit source">
+      <i class="mdi mdi-pencil"></i>
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import type { Source } from "@pipelab/shared";
+
+const props = defineProps<{
+  source: Source;
+  lastExport: Date | null;
+  sourceWarning: boolean;
+}>();
+
+defineEmits<{ (e: "edit"): void }>();
+
+const ENGINE_META: Record<string, { label: string; icon: string }> = {
+  construct3: { label: "Construct 3", icon: "mdi-cube-outline" },
+  godot: { label: "Godot", icon: "mdi-cube" },
+  folder: { label: "Folder", icon: "mdi-folder-outline" },
+};
+
+const engineLabel = computed(() => ENGINE_META[props.source.type]?.label ?? "Unknown");
+const engineIcon = computed(() => ENGINE_META[props.source.type]?.icon ?? "mdi-help-circle");
+
+const pathDisplay = computed(() => {
+  const p = props.source.path;
+  if (!p) return "No path set";
+  if (p.length <= 40) return p;
+  return "…" + p.slice(-37);
+});
+
+const formatTimeAgo = (d: Date) => {
+  const seconds = Math.floor((Date.now() - d.getTime()) / 1000);
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+};
+</script>
+
+<style scoped>
+.source-card {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  height: 48px;
+  padding: 0 12px;
+  background: #1e1e24;
+  border: 1px solid #2a2a30;
+  border-radius: 8px;
+  flex: 1;
+  min-width: 0;
+}
+
+.source-card.warning {
+  border-color: #f59e0b;
+}
+
+.engine-icon {
+  font-size: 16px;
+  color: #8b8b96;
+  flex-shrink: 0;
+}
+
+.source-text {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1;
+}
+
+.engine-name {
+  font-size: 13px;
+  color: #e4e4e7;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.source-path {
+  font-size: 11px;
+  color: #8b8b96;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.last-export {
+  font-size: 11px;
+  color: #8b8b96;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.warning-text {
+  font-size: 11px;
+  color: #f59e0b;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.edit-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  background: none;
+  border: none;
+  border-radius: 4px;
+  color: #8b8b96;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s, color 0.15s, background 0.15s;
+  flex-shrink: 0;
+}
+
+.source-card:hover .edit-btn {
+  opacity: 1;
+}
+
+.edit-btn:hover {
+  background: #2a2a30;
+  color: #e4e4e7;
+}
+
+.edit-btn .mdi {
+  font-size: 14px;
+}
+</style>

--- a/apps/ui/src/components/paths/SourceCard.vue
+++ b/apps/ui/src/components/paths/SourceCard.vue
@@ -46,13 +46,13 @@ const pathDisplay = computed(() => {
 });
 
 const formatTimeAgo = (d: Date) => {
-  const seconds = Math.floor((Date.now() - d.getTime()) / 1000);
-  if (seconds < 60) return `${seconds}s ago`;
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  return `${Math.floor(hours / 24)}d ago`;
+  const s = Math.floor((Date.now() - d.getTime()) / 1000);
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.floor(h / 24)}d ago`;
 };
 </script>
 

--- a/apps/ui/src/components/paths/SourceEditPanel.vue
+++ b/apps/ui/src/components/paths/SourceEditPanel.vue
@@ -10,7 +10,7 @@
           :key="opt.value"
           class="engine-option"
           :class="{ active: source.type === opt.value }"
-          @click="onEnginePick(opt.value)"
+          @click="currentType = opt.value"
         >
           <i class="mdi" :class="opt.icon"></i>
           <span>{{ opt.label }}</span>
@@ -38,7 +38,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from "vue";
+import { ref } from "vue";
 import type { Source, EngineType } from "@pipelab/shared";
 import { useAPI } from "@renderer/composables/api";
 
@@ -51,23 +51,11 @@ const emit = defineEmits<{
 const path = ref(props.source.path);
 const currentType = ref<EngineType>(props.source.type);
 
-watch(
-  () => props.source,
-  (s) => {
-    path.value = s.path;
-    currentType.value = s.type;
-  },
-);
-
 const engineOptions: { value: EngineType; label: string; icon: string }[] = [
   { value: "construct3", label: "Construct 3", icon: "mdi-cube-outline" },
   { value: "godot", label: "Godot", icon: "mdi-cube" },
   { value: "folder", label: "Folder", icon: "mdi-folder-outline" },
 ];
-
-const onEnginePick = (type: EngineType) => {
-  currentType.value = type;
-};
 
 const api = useAPI();
 const browse = async () => {

--- a/apps/ui/src/components/paths/SourceEditPanel.vue
+++ b/apps/ui/src/components/paths/SourceEditPanel.vue
@@ -1,0 +1,241 @@
+<template>
+  <div class="edit-backdrop" @click.self="$emit('close')">
+    <div class="edit-panel">
+      <h3 class="panel-title">Source</h3>
+
+      <label class="section-label">Engine</label>
+      <div class="engine-picker">
+        <button
+          v-for="opt in engineOptions"
+          :key="opt.value"
+          class="engine-option"
+          :class="{ active: source.type === opt.value }"
+          @click="onEnginePick(opt.value)"
+        >
+          <i class="mdi" :class="opt.icon"></i>
+          <span>{{ opt.label }}</span>
+        </button>
+      </div>
+
+      <label class="section-label">Folder</label>
+      <div class="folder-picker">
+        <input
+          v-model="path"
+          class="path-input"
+          type="text"
+          placeholder="Choose a folder"
+          readonly
+        />
+        <button class="browse-btn" @click="browse">Browse</button>
+      </div>
+
+      <div class="panel-actions">
+        <button class="cancel-btn" @click="$emit('close')">Cancel</button>
+        <button class="save-btn" :disabled="!path" @click="save">Save</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from "vue";
+import type { Source, EngineType } from "@pipelab/shared";
+import { useAPI } from "@renderer/composables/api";
+
+const props = defineProps<{ source: Source }>();
+const emit = defineEmits<{
+  (e: "save", source: Source): void;
+  (e: "close"): void;
+}>();
+
+const path = ref(props.source.path);
+const currentType = ref<EngineType>(props.source.type);
+
+watch(
+  () => props.source,
+  (s) => {
+    path.value = s.path;
+    currentType.value = s.type;
+  },
+);
+
+const engineOptions: { value: EngineType; label: string; icon: string }[] = [
+  { value: "construct3", label: "Construct 3", icon: "mdi-cube-outline" },
+  { value: "godot", label: "Godot", icon: "mdi-cube" },
+  { value: "folder", label: "Folder", icon: "mdi-folder-outline" },
+];
+
+const onEnginePick = (type: EngineType) => {
+  currentType.value = type;
+};
+
+const api = useAPI();
+const browse = async () => {
+  const result = await api.execute("dialog:showOpenDialog", {
+    properties: ["openDirectory"],
+  });
+  if (result.type === "success" && (result as any).result) {
+    path.value = (result as any).result;
+  }
+};
+
+const save = () => {
+  if (!path.value) return;
+  const out: Source = { type: currentType.value, path: path.value } as Source;
+  emit("save", out);
+};
+</script>
+
+<style scoped>
+.edit-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 80px;
+  z-index: 1000;
+}
+
+.edit-panel {
+  background: #18181c;
+  border: 1px solid #2a2a30;
+  border-radius: 8px;
+  padding: 24px;
+  width: 480px;
+  max-width: 90vw;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.panel-title {
+  font-size: 16px;
+  font-weight: 500;
+  color: #e4e4e7;
+  margin: 0;
+}
+
+.section-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #8b8b96;
+  margin-bottom: -8px;
+}
+
+.engine-picker {
+  display: flex;
+  gap: 8px;
+}
+
+.engine-option {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 16px 8px;
+  background: #1e1e24;
+  border: 1px solid #2a2a30;
+  border-radius: 8px;
+  color: #8b8b96;
+  font-size: 12px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.engine-option:hover {
+  background: #2a2a30;
+  color: #e4e4e7;
+}
+
+.engine-option.active {
+  border-color: #6366f1;
+  color: #e4e4e7;
+  background: rgba(99, 102, 241, 0.08);
+}
+
+.engine-option .mdi {
+  font-size: 24px;
+}
+
+.folder-picker {
+  display: flex;
+  gap: 8px;
+}
+
+.path-input {
+  flex: 1;
+  padding: 8px 12px;
+  background: #1e1e24;
+  border: 1px solid #2a2a30;
+  border-radius: 6px;
+  color: #e4e4e7;
+  font-size: 13px;
+  font-family: monospace;
+}
+
+.path-input:focus {
+  outline: none;
+  border-color: #6366f1;
+}
+
+.browse-btn {
+  padding: 8px 16px;
+  background: #1e1e24;
+  border: 1px solid #2a2a30;
+  border-radius: 6px;
+  color: #e4e4e7;
+  font-size: 13px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.browse-btn:hover {
+  background: #2a2a30;
+}
+
+.panel-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.cancel-btn,
+.save-btn {
+  padding: 8px 16px;
+  border-radius: 6px;
+  font-size: 13px;
+  cursor: pointer;
+  border: 1px solid #2a2a30;
+  transition: all 0.15s;
+}
+
+.cancel-btn {
+  background: none;
+  color: #8b8b96;
+}
+
+.cancel-btn:hover {
+  color: #e4e4e7;
+  background: #1e1e24;
+}
+
+.save-btn {
+  background: #22c55e;
+  border-color: #22c55e;
+  color: white;
+}
+
+.save-btn:hover:not(:disabled) {
+  background: #16a34a;
+}
+
+.save-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+</style>

--- a/apps/ui/src/composables/websocket-client.ts
+++ b/apps/ui/src/composables/websocket-client.ts
@@ -52,6 +52,11 @@ export class WebSocketClient {
       if (!isDev) {
         const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
         defaultUrl = `${protocol}//${window.location.host}`;
+      } else {
+        // In dev, connect back to whichever host served the UI so remote
+        // browsers (e.g. over Tailscale) reach the CLI server. Identical to
+        // localhost when developing locally.
+        defaultUrl = `ws://${window.location.hostname}:${websocketPort}`;
       }
     }
 

--- a/apps/ui/src/pages/paths.vue
+++ b/apps/ui/src/pages/paths.vue
@@ -22,7 +22,6 @@
             :key="index"
             :destination="dest"
             :state="runState.destinations[index]"
-            :credential-saving="savingCredential === index"
             @update-delivery="(d) => updateDelivery(index, d)"
             @remove="removeDestination(index)"
             @ship="ship(index)"
@@ -90,16 +89,12 @@ import type {
   PathRunState,
 } from "@pipelab/shared";
 
-// ─── Project / Path ─────────────────────────────────────────────────────────
-
 const projectName = ref("My Game");
 const lastExport = ref<Date | null>(null);
 const sourceWarning = ref(false);
 const editingSource = ref(false);
 const showAddDestination = ref(false);
 const savingCredential = ref<number | null>(null);
-
-// ─── Path state ─────────────────────────────────────────────────────────────
 
 const path = ref<Path>({
   version: "1.0.0",
@@ -111,14 +106,11 @@ const runState = ref<PathRunState>({
   destinations: {},
 });
 
-// ─── Derived ─────────────────────────────────────────────────────────────────
-
 const readyCount = computed(
   () =>
-    path.value.destinations.filter((d, i) => {
-      const s = runState.value.destinations[i];
-      return s?.state === "ready";
-    }).length,
+    path.value.destinations.filter(
+      (_, i) => runState.value.destinations[i]?.state === "ready",
+    ).length,
 );
 
 const isAnyShipping = computed(
@@ -133,15 +125,11 @@ const shipAllLabel = computed(() => {
   return `Ship ${n} ready`;
 });
 
-// ─── Source ─────────────────────────────────────────────────────────────────
-
 const saveSource = (source: Source) => {
   path.value.source = source;
   sourceWarning.value = false;
   editingSource.value = false;
 };
-
-// ─── Destinations ───────────────────────────────────────────────────────────
 
 const addDestination = (type: Destination["type"]) => {
   const newDest = createDestination(type);
@@ -191,8 +179,6 @@ const saveCredential = async (index: number, credentialId: string) => {
   savingCredential.value = null;
 };
 
-// ─── Run ────────────────────────────────────────────────────────────────────
-
 const ship = (index: number) => {
   runState.value.destinations[index] = {
     state: "shipping",
@@ -228,8 +214,6 @@ const skip = (index: number) => {
     finishedAt: Date.now(),
   };
 };
-
-// ─── Navigation ─────────────────────────────────────────────────────────────
 
 const router = useRouter();
 const goAdvanced = () => {

--- a/apps/ui/src/pages/paths.vue
+++ b/apps/ui/src/pages/paths.vue
@@ -1,0 +1,383 @@
+<template>
+  <div class="paths-page">
+    <Layout>
+      <div class="paths-content">
+
+        <!-- Header strip -->
+        <div class="paths-header">
+          <span class="project-name">{{ projectName }}</span>
+          <SourceCard
+            :source="path.source"
+            :last-export="lastExport"
+            :source-warning="sourceWarning"
+            @edit="editingSource = true"
+          />
+          <button class="advanced-link" @click="goAdvanced">Advanced</button>
+        </div>
+
+        <!-- Destinations -->
+        <div class="destinations-list">
+          <DestinationRow
+            v-for="(dest, index) in path.destinations"
+            :key="index"
+            :destination="dest"
+            :state="runState.destinations[index]"
+            :credential-saving="savingCredential === index"
+            @update-delivery="(d) => updateDelivery(index, d)"
+            @remove="removeDestination(index)"
+            @ship="ship(index)"
+            @retry="retry(index)"
+            @skip="skip(index)"
+            @save-credential="(cred) => saveCredential(index, cred)"
+          />
+
+          <!-- Empty state -->
+          <div v-if="path.destinations.length === 0" class="empty-destinations">
+            <i class="mdi mdi-package-variant-closed empty-icon"></i>
+            <p class="empty-heading">No destinations yet</p>
+            <p class="empty-sub">Add where you want your game to go.</p>
+          </div>
+        </div>
+
+        <!-- Add destination -->
+        <button class="add-destination-btn" @click="showAddDestination = true">
+          <i class="mdi mdi-plus"></i>
+          Add destination
+        </button>
+
+        <!-- Ship all -->
+        <button
+          class="ship-all-btn"
+          :disabled="readyCount === 0 || isAnyShipping"
+          @click="shipAll"
+        >
+          {{ shipAllLabel }}
+        </button>
+      </div>
+    </Layout>
+
+    <!-- Source edit panel -->
+    <SourceEditPanel
+      v-if="editingSource"
+      :source="path.source"
+      @save="saveSource"
+      @close="editingSource = false"
+    />
+
+    <!-- Add destination picker -->
+    <AddDestinationSheet
+      v-if="showAddDestination"
+      :used-types="path.destinations.map((d) => d.type)"
+      @pick="addDestination"
+      @close="showAddDestination = false"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from "vue";
+import { useRouter } from "vue-router";
+import Layout from "@renderer/components/Layout.vue";
+import SourceCard from "@renderer/components/paths/SourceCard.vue";
+import SourceEditPanel from "@renderer/components/paths/SourceEditPanel.vue";
+import DestinationRow from "@renderer/components/paths/DestinationRow.vue";
+import AddDestinationSheet from "@renderer/components/paths/AddDestinationSheet.vue";
+import type {
+  Path,
+  Source,
+  Destination,
+  DeliveryKind,
+  PathRunState,
+} from "@pipelab/shared";
+
+// ─── Project / Path ─────────────────────────────────────────────────────────
+
+const projectName = ref("My Game");
+const lastExport = ref<Date | null>(null);
+const sourceWarning = ref(false);
+const editingSource = ref(false);
+const showAddDestination = ref(false);
+const savingCredential = ref<number | null>(null);
+
+// ─── Path state ─────────────────────────────────────────────────────────────
+
+const path = ref<Path>({
+  version: "1.0.0",
+  source: { type: "construct3", path: "" },
+  destinations: [],
+});
+
+const runState = ref<PathRunState>({
+  destinations: {},
+});
+
+// ─── Derived ─────────────────────────────────────────────────────────────────
+
+const readyCount = computed(
+  () =>
+    path.value.destinations.filter((d, i) => {
+      const s = runState.value.destinations[i];
+      return s?.state === "ready";
+    }).length,
+);
+
+const isAnyShipping = computed(
+  () => Object.values(runState.value.destinations).some((s) => s?.state === "shipping"),
+);
+
+const shipAllLabel = computed(() => {
+  const n = readyCount.value;
+  if (n === 0) return "Ship all ready";
+  if (isAnyShipping.value) return `Shipping ${n}…`;
+  if (n === 1) return "Ship all ready";
+  return `Ship ${n} ready`;
+});
+
+// ─── Source ─────────────────────────────────────────────────────────────────
+
+const saveSource = (source: Source) => {
+  path.value.source = source;
+  sourceWarning.value = false;
+  editingSource.value = false;
+};
+
+// ─── Destinations ───────────────────────────────────────────────────────────
+
+const addDestination = (type: Destination["type"]) => {
+  const newDest = createDestination(type);
+  path.value.destinations.push(newDest);
+  runState.value.destinations[path.value.destinations.length - 1] = {
+    state: "ready",
+  };
+  showAddDestination.value = false;
+};
+
+const createDestination = (type: Destination["type"]): Destination => {
+  switch (type) {
+    case "steam":
+      return { type: "steam", delivery: "app", appId: "", credentialId: "" };
+    case "itch":
+      return { type: "itch", delivery: "archive", project: "", credentialId: "" };
+    case "poki":
+      return { type: "poki", delivery: "web", gameId: "", credentialId: "" };
+    case "discord-activity":
+      return { type: "discord-activity", delivery: "app", appId: "", credentialId: "" };
+    case "netlify":
+      return { type: "netlify", delivery: "web", site: "", credentialId: "" };
+    case "web":
+      return { type: "web", delivery: "web", outputDir: "" };
+    case "folder":
+      return { type: "folder", delivery: "archive", outputDir: "" };
+  }
+};
+
+const removeDestination = (index: number) => {
+  path.value.destinations.splice(index, 1);
+  delete runState.value.destinations[index];
+};
+
+const updateDelivery = (index: number, delivery: DeliveryKind) => {
+  const dest = path.value.destinations[index];
+  if (dest) {
+    (dest as any).delivery = delivery;
+  }
+};
+
+const saveCredential = async (index: number, credentialId: string) => {
+  savingCredential.value = index;
+  await new Promise((r) => setTimeout(r, 600)); // mock async
+  const dest = path.value.destinations[index] as any;
+  if (dest) dest.credentialId = credentialId;
+  savingCredential.value = null;
+};
+
+// ─── Run ────────────────────────────────────────────────────────────────────
+
+const ship = (index: number) => {
+  runState.value.destinations[index] = {
+    state: "shipping",
+    startedAt: Date.now(),
+  };
+  // Mock run: succeed after 2s
+  setTimeout(() => {
+    runState.value.destinations[index] = {
+      state: "shipped",
+      startedAt: Date.now() - 2000,
+      finishedAt: Date.now(),
+      lastLog: "Upload complete.",
+    };
+  }, 2000);
+};
+
+const shipAll = () => {
+  path.value.destinations.forEach((_, i) => {
+    if (runState.value.destinations[i]?.state === "ready") {
+      ship(i);
+    }
+  });
+};
+
+const retry = (index: number) => {
+  runState.value.destinations[index] = { state: "ready" };
+  ship(index);
+};
+
+const skip = (index: number) => {
+  runState.value.destinations[index] = {
+    state: "skipped",
+    finishedAt: Date.now(),
+  };
+};
+
+// ─── Navigation ─────────────────────────────────────────────────────────────
+
+const router = useRouter();
+const goAdvanced = () => {
+  router.push("/scenarios/editor/new");
+};
+</script>
+
+<style scoped>
+.paths-page {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.paths-content {
+  max-width: 800px;
+  margin: 0 auto;
+  width: 100%;
+  padding: 0 24px 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+/* ─── Header ────────────────────────────────────────────────────────────── */
+
+.paths-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px 0;
+  min-height: 56px;
+  border-bottom: 1px solid #2a2a30;
+  margin-bottom: 24px;
+}
+
+.project-name {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #8b8b96;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.advanced-link {
+  margin-left: auto;
+  font-size: 12px;
+  color: #8b8b96;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 4px;
+  white-space: nowrap;
+  flex-shrink: 0;
+  transition: color 0.15s;
+}
+
+.advanced-link:hover {
+  color: #e4e4e7;
+}
+
+/* ─── Destinations list ────────────────────────────────────────────────── */
+
+.destinations-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+/* ─── Empty state ──────────────────────────────────────────────────────── */
+
+.empty-destinations {
+  text-align: center;
+  padding: 48px 24px;
+  color: #8b8b96;
+}
+
+.empty-icon {
+  font-size: 32px;
+  color: #3a3a42;
+  display: block;
+  margin-bottom: 12px;
+}
+
+.empty-heading {
+  font-size: 16px;
+  font-weight: 500;
+  color: #e4e4e7;
+  margin: 0 0 4px;
+}
+
+.empty-sub {
+  font-size: 13px;
+  color: #8b8b96;
+  margin: 0;
+}
+
+/* ─── Add destination ───────────────────────────────────────────────────── */
+
+.add-destination-btn {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  background: none;
+  border: none;
+  color: #8b8b96;
+  cursor: pointer;
+  font-size: 13px;
+  border-radius: 8px;
+  width: 100%;
+  margin-bottom: 16px;
+  transition: background 0.15s, color 0.15s;
+}
+
+.add-destination-btn:hover {
+  background: #1e1e24;
+  color: #e4e4e7;
+}
+
+.add-destination-btn .mdi {
+  font-size: 18px;
+}
+
+/* ─── Ship all ──────────────────────────────────────────────────────────── */
+
+.ship-all-btn {
+  width: 100%;
+  height: 48px;
+  background: #1e1e24;
+  border: 1px solid #2a2a30;
+  border-radius: 8px;
+  color: #e4e4e7;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s, opacity 0.15s;
+}
+
+.ship-all-btn:not(:disabled):hover {
+  background: #2a2a30;
+}
+
+.ship-all-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+</style>

--- a/apps/ui/src/router/router.ts
+++ b/apps/ui/src/router/router.ts
@@ -67,11 +67,11 @@ const routes: RouterOptions["routes"] = [
     },
   },
   {
-    path: "/simple-editor",
-    name: "SimpleEditor",
-    component: () => import("../pages/simple-editor.vue"),
+    path: "/paths",
+    name: "Paths",
+    component: () => import("../pages/paths.vue"),
     meta: {
-      title: "Simple Editor",
+      title: "Paths",
     },
   },
 ];

--- a/packages/core-node/src/websocket-server.ts
+++ b/packages/core-node/src/websocket-server.ts
@@ -108,7 +108,9 @@ export class WebSocketServer {
         });
 
         if (!server.listening) {
-          server.listen(port, "127.0.0.1", () => {
+          // Bind all interfaces so remote browsers (e.g. over Tailscale) can
+          // reach the dev server. Local dev is unaffected.
+          server.listen(port, "0.0.0.0", () => {
             this.connectionState = "connected";
             logger().info(`WebSocket server listening on port ${port}`);
             this.isReady = true;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -61,6 +61,7 @@ export * from "./utils";
 export * from "./validation";
 export * from "./variables";
 export * from "./websocket.types";
+export * from "./path";
 
 // 4. Configuration Sub-packages
 export * from "./config/projects-definition"; // <-- RE-ADDED

--- a/packages/shared/src/path.ts
+++ b/packages/shared/src/path.ts
@@ -1,0 +1,49 @@
+// Path data model — what the user configures. The compiler turns this into
+// the internal SavedFile canvas at runtime. The user never sees a canvas.
+
+export type DeliveryKind = "app" | "web" | "archive";
+
+export type DestinationType =
+  | "steam"
+  | "itch"
+  | "poki"
+  | "discord-activity"
+  | "netlify"
+  | "web"
+  | "folder";
+
+export type EngineType = "construct3" | "godot" | "folder";
+
+export type Source =
+  | { type: "construct3"; path: string }
+  | { type: "godot"; path: string }
+  | { type: "folder"; path: string };
+
+export type Destination =
+  | { type: "steam"; delivery: "app"; appId: string; credentialId: string }
+  | { type: "itch"; delivery: DeliveryKind; project: string; credentialId: string }
+  | { type: "poki"; delivery: "web"; gameId: string; credentialId: string }
+  | { type: "discord-activity"; delivery: "app"; appId: string; credentialId: string }
+  | { type: "netlify"; delivery: "web"; site: string; credentialId: string }
+  | { type: "web"; delivery: "web"; outputDir: string }
+  | { type: "folder"; delivery: DeliveryKind; outputDir: string };
+
+export type Path = {
+  version: "1.0.0";
+  source: Source;
+  destinations: Destination[];
+};
+
+export type DestinationState = "ready" | "shipping" | "shipped" | "failed" | "skipped";
+
+export type DestinationRun = {
+  state: DestinationState;
+  startedAt?: number;
+  finishedAt?: number;
+  lastLog?: string;
+  error?: string;
+};
+
+export type PathRunState = {
+  destinations: Record<string, DestinationRun>;
+};


### PR DESCRIPTION
## What

A new **Paths** screen replaces the dead simple-editor. It provides a beginner-friendly shipping companion for video game developers:

- **Source card** at the top: engine type (Construct 3, Godot, Folder) + folder path + last-export timestamp
- **Destination rows** below: one per platform (Steam, Itch.io, Poki, Discord Activity, Netlify, Web, Folder)
- Each row has a **delivery selector** (App / Web / Archive — only valid options shown) and a **Ship** button
- **Add destination** via inline grid picker, **remove** via hover X — no navigation
- **Credentials** prompted inline on first use, stored via system keychain reference
- **Ship all** button ships all ready destinations in parallel
- Per-destination states: ready → shipping (progress bar + log) → shipped (timestamp) | failed (retry/skip) | skipped

Reachable from the sidebar (**Paths** entry between Dashboard and Connections).

## Remote preview (Tailscale)

- `packages/core-node/src/websocket-server.ts`: bind `0.0.0.0` so remote browsers can reach the CLI WebSocket server
- `apps/ui/src/composables/websocket-client.ts`: dev client connects to `window.location.hostname` instead of hardcoded `localhost`
- `.agents/skills/tailscale-preview/SKILL.md`: launch + verify procedure with gotchas (SIGSTOP on attached terminals, localhost-only defaults)

Verified live: UI 200 on `/paths` via Tailscale IP, WebSocket handshake opens, CLI process healthy.

## Files

- `packages/shared/src/path.ts` — Path data model (Source, Destination, DeliveryKind, Path, RunState types)
- `apps/ui/src/pages/paths.vue` — Path Builder page
- `apps/ui/src/components/paths/` — SourceCard, SourceEditPanel, DestinationRow, AddDestinationSheet
- `apps/ui/src/router/router.ts` — `/paths` route replaces dead `/simple-editor`

## Next

Backend not yet wired — ship behavior is mocked (2s timeout → shipped). IPC handlers and the path-to-canvas compiler are the next slice.

## Checklist

- [x] UI typecheck passes
- [x] Lint clean on new files
- [x] Routes correctly to new page + sidebar entry
- [x] Remote access verified over Tailscale (UI 200, WS open)