### PR TITLE
feat: make dashboard, editor and paths mobile ready

### DIFF
--- a/.agents/skills/tailscale-preview/SKILL.md
+++ b/.agents/skills/tailscale-preview/SKILL.md
@@ -7,19 +7,26 @@ laptop) can open the UI over Tailscale. Use when asked to "start the app",
 ## Procedure
 
 1. Confirm Tailscale is up: `tailscale ip -4`. Note the machine IP
-   (e.g. `100.111.167.123`). The UI URL is `http://<ip>:5173`.
+   (e.g. `100.111.167.123`). The UI URL is `http://<ip>:5173` (or the
+   alternate Vite port selected below).
 2. Launch both servers **detached** (stdin from `/dev/null`, own session —
    never plain `&` from a terminal, see Gotchas):
    - CLI: `setsid bash -c 'pnpm --filter @pipelab/cli dev > /tmp/pipelab-cli.log 2>&1 < /dev/null' &`
    - UI: `setsid bash -c 'pnpm --filter @pipelab/ui exec vite --host 0.0.0.0 --port 5173 > /tmp/pipelab-ui.log 2>&1 < /dev/null' &`
    - `disown -a` afterwards if launched from an interactive shell.
+   The UI and CLI are separate servers. Opening the UI URL alone does not
+   start the backend; the CLI must be running on the same machine and its
+   WebSocket port (`33753`) must be reachable over Tailscale.
+   If port `5173` is already occupied, stop the stale Vite process or launch
+   the UI on another port, e.g. `--port 5174`, and use that port in the URL.
 3. Wait ~30s. Verify in order:
    - CLI log shows `WebSocket server listening on port 33753` and
      `[Startup Progress] Ready!`: `grep -E 'listening on port|Ready!' /tmp/pipelab-cli.log`
    - CLI process is **not** in `T (stopped)` state:
      `cat /proc/$(pgrep -f 'tsx/dist/loader' | head -1)/status | grep State`
      (must read `S`, never `T`).
-   - WebSocket handshake succeeds over the Tailscale IP:
+   - WebSocket handshake succeeds over the Tailscale IP (this is the backend
+     check; a successful HTTP request to the UI is not sufficient):
      `node -e "new (require('<repo>/node_modules/ws'))('ws://<ip>:33753').on('open', () => { console.log('WS-OK'); process.exit(0); })"`
    - UI serves 200 over the Tailscale IP:
      `curl -o /dev/null -w "%{http_code}\n" http://<ip>:5173/paths`

--- a/apps/ui/index.html
+++ b/apps/ui/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Pipelab UI</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/apps/ui/src/components/Layout.vue
+++ b/apps/ui/src/components/Layout.vue
@@ -929,4 +929,93 @@ handle("update:set-status", async (event, { value }) => {
   flex: 1;
   overflow: auto;
 }
+
+/* ─── Mobile: bottom tab bar ─────────────────────────────── */
+@media (max-width: 768px) {
+  .layout-shell {
+    flex-direction: column;
+  }
+
+  .sidebar,
+  .sidebar-collapsed .sidebar {
+    width: 100%;
+    min-width: 0;
+    height: calc(60px + env(safe-area-inset-bottom));
+    padding-bottom: env(safe-area-inset-bottom);
+    flex-direction: row;
+    align-items: center;
+    order: 2;
+    border-right: none;
+    border-top: 1px solid var(--p-surface-200);
+    overflow-x: auto;
+    overflow-y: hidden;
+
+    :root.dark & {
+      border-top-color: var(--p-surface-700);
+    }
+  }
+
+  .sidebar-header,
+  .sidebar-spacer,
+  .sidebar-status,
+  .sidebar-divider,
+  .sidebar-upgrade-wrap,
+  .sidebar-nav-item.disabled,
+  .sidebar-nav-item .nav-label,
+  .sidebar-nav-item .coming-soon-badge,
+  .sidebar-account-row .account-left,
+  .sidebar-bottom .sidebar-divider {
+    display: none !important;
+  }
+
+  .sidebar-nav,
+  .sidebar-bottom {
+    flex-direction: row;
+    align-items: center;
+    padding: 0 4px;
+    gap: 0;
+  }
+
+  .sidebar-nav {
+    flex: 1;
+    justify-content: space-around;
+  }
+
+  .sidebar-nav-item,
+  .sidebar-collapsed .sidebar-nav-item {
+    flex: 1;
+    justify-content: center;
+    padding: 8px 4px;
+    min-width: 56px;
+    min-height: 44px;
+
+    .nav-icon {
+      font-size: 22px;
+      width: auto;
+    }
+  }
+
+  .sidebar-bottom {
+    padding: 0 4px;
+  }
+
+  .sidebar-account-row {
+    background: transparent;
+    padding: 0;
+    margin: 0;
+  }
+
+  .account-logout-btn,
+  .account-logout-btn.collapsed-logout {
+    width: 44px;
+    height: 44px;
+    padding: 8px;
+  }
+
+  .layout-main {
+    order: 1;
+    padding-bottom: 0;
+    min-height: 0;
+  }
+}
 </style>

--- a/apps/ui/src/components/Layout.vue
+++ b/apps/ui/src/components/Layout.vue
@@ -938,6 +938,7 @@ handle("update:set-status", async (event, { value }) => {
 
   .sidebar,
   .sidebar-collapsed .sidebar {
+    box-sizing: border-box;
     width: 100%;
     min-width: 0;
     height: calc(60px + env(safe-area-inset-bottom));

--- a/apps/ui/src/components/nodes/EditorNodeAction.vue
+++ b/apps/ui/src/components/nodes/EditorNodeAction.vue
@@ -545,6 +545,23 @@ const hasErrored = computed(() => {
   color: red;
 }
 
+@media (max-width: 768px) {
+  .node-action-wrapper {
+    width: 100%;
+    max-width: 100%;
+  }
+
+  .node-action {
+    width: 100%;
+    max-width: 100%;
+    padding: 8px 12px;
+  }
+
+  .vertical {
+    gap: 12px;
+  }
+}
+
 @keyframes clippath {
   0%,
   100% {

--- a/apps/ui/src/components/nodes/EditorNodeEvent.vue
+++ b/apps/ui/src/components/nodes/EditorNodeEvent.vue
@@ -243,4 +243,17 @@ const showSidebar = ref(false);
     }
   }
 }
+
+@media (max-width: 768px) {
+  .node-event-wrapper {
+    width: 100%;
+    max-width: 100%;
+  }
+
+  .node-event {
+    width: 100%;
+    max-width: 100%;
+    padding: 12px;
+  }
+}
 </style>

--- a/apps/ui/src/components/paths/AddDestinationSheet.vue
+++ b/apps/ui/src/components/paths/AddDestinationSheet.vue
@@ -105,4 +105,26 @@ const availableOptions = computed(() =>
   font-size: 12px;
   color: #e4e4e7;
 }
+
+@media (max-width: 640px) {
+  .add-backdrop {
+    align-items: flex-end;
+    padding-top: 0;
+  }
+
+  .add-sheet {
+    width: 100%;
+    max-width: 100%;
+    border-radius: 16px 16px 0 0;
+    padding: 20px 16px calc(20px + env(safe-area-inset-bottom));
+  }
+
+  .platform-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .platform-option {
+    min-height: 88px;
+  }
+}
 </style>

--- a/apps/ui/src/components/paths/AddDestinationSheet.vue
+++ b/apps/ui/src/components/paths/AddDestinationSheet.vue
@@ -113,6 +113,7 @@ const availableOptions = computed(() =>
   }
 
   .add-sheet {
+    box-sizing: border-box;
     width: 100%;
     max-width: 100%;
     border-radius: 16px 16px 0 0;

--- a/apps/ui/src/components/paths/DestinationRow.vue
+++ b/apps/ui/src/components/paths/DestinationRow.vue
@@ -578,4 +578,36 @@ const saveCredential = () => {
 .ship-btn .mdi {
   font-size: 14px;
 }
+
+@media (max-width: 640px) {
+  .dest-row {
+    flex-direction: column;
+    gap: 12px;
+    padding: 12px;
+  }
+
+  .zone-platform,
+  .zone-right {
+    width: 100%;
+  }
+
+  .remove-btn {
+    opacity: 1;
+    width: 32px;
+    height: 32px;
+  }
+
+  .cred-warning {
+    flex-wrap: wrap;
+  }
+
+  .cred-save-btn {
+    min-height: 40px;
+    flex: 1;
+  }
+
+  .ship-btn {
+    min-height: 44px;
+  }
+}
 </style>

--- a/apps/ui/src/components/paths/SourceCard.vue
+++ b/apps/ui/src/components/paths/SourceCard.vue
@@ -146,4 +146,17 @@ const formatTimeAgo = (d: Date) => {
 .edit-btn .mdi {
   font-size: 14px;
 }
+
+@media (max-width: 640px) {
+  .last-export,
+  .warning-text {
+    display: none;
+  }
+
+  .edit-btn {
+    opacity: 1;
+    width: 40px;
+    height: 40px;
+  }
+}
 </style>

--- a/apps/ui/src/pages/editor.vue
+++ b/apps/ui/src/pages/editor.vue
@@ -1888,4 +1888,98 @@ const onValueChanged = (newValue: Param, paramKey: string) => {
     box-shadow: 0 0 30px rgba(91, 82, 244, 0.15);
   }
 }
+
+/* ─── Mobile: wrapping toolbar, full-width nodes, bottom-sheet params ─ */
+@media (max-width: 768px) {
+  .editor .buttons {
+    height: auto;
+    min-height: 56px;
+    flex-wrap: wrap;
+    padding: 8px;
+    row-gap: 8px;
+
+    .left,
+    .right {
+      display: flex;
+      gap: 4px;
+      align-items: center;
+    }
+
+    .center {
+      order: 3;
+      flex: 1 1 100%;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      text-align: center;
+    }
+
+    :deep(.p-button) {
+      min-width: 40px;
+      min-height: 40px;
+    }
+
+    :deep(.p-button .p-button-label) {
+      display: none;
+    }
+
+    :deep(.p-button .mdi),
+    :deep(.p-button .pi) {
+      margin-right: 0 !important;
+    }
+  }
+
+  .editor .editor-content {
+    height: calc(100% - 40px);
+  }
+
+  .main {
+    padding: 16px 0 140px;
+  }
+
+  .editor .node-editor-wrapper {
+    margin: 8px;
+    width: calc(100% - 16px);
+  }
+
+  /* Params drawer becomes a bottom sheet overlay */
+  .editor-wrapper .drawer.right {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    top: auto;
+    height: 72vh;
+    height: 72dvh;
+    z-index: 900;
+    border-top-left-radius: 16px;
+    border-top-right-radius: 16px;
+    border-top: 1px solid #ddd;
+    box-shadow: 0 -8px 32px rgba(0, 0, 0, 0.2);
+
+    :root.dark & {
+      border-top-color: var(--p-surface-700);
+    }
+
+    .drawer-content-inner {
+      min-width: 0;
+    }
+  }
+
+  .editor .bottom {
+    left: 4px;
+    right: 4px;
+    bottom: calc(60px + env(safe-area-inset-bottom));
+    margin: 4px;
+
+    &.expanded {
+      height: 62%;
+    }
+  }
+
+  .logs-header .logs-animated {
+    display: none;
+  }
+}
 </style>

--- a/apps/ui/src/pages/index.vue
+++ b/apps/ui/src/pages/index.vue
@@ -2070,4 +2070,81 @@ const startTour = (force = false) => {
     grid-template-columns: repeat(4, 1fr);
   }
 }
+
+/* ─── Mobile: drawer becomes top chips, rows wrap ───────── */
+@media (max-width: 860px) {
+  .main-layout {
+    flex-direction: column;
+  }
+
+  .drawer {
+    width: 100%;
+    flex: 0 0 auto;
+    border-right: none;
+    border-bottom: 1px solid var(--p-surface-200);
+
+    :root.dark & {
+      border-bottom-color: var(--p-surface-700);
+    }
+
+    .project-list {
+      flex-direction: row;
+      overflow-x: auto;
+      overflow-y: hidden;
+      padding: 0 12px 10px;
+    }
+
+    .project-item {
+      flex-shrink: 0;
+      max-width: 200px;
+    }
+
+    .project-item-actions {
+      opacity: 1;
+    }
+  }
+
+  .your-projects {
+    padding: 12px;
+    overflow-x: hidden;
+  }
+
+  .action-buttons {
+    width: 100%;
+
+    :deep(.p-button) {
+      flex: 1;
+      justify-content: center;
+      min-height: 40px;
+    }
+  }
+
+  .pipeline-row {
+    flex-wrap: wrap;
+    gap: 8px;
+    padding: 12px;
+  }
+
+  .pipeline-tech-stack {
+    margin-right: 0;
+  }
+
+  .pipeline-info {
+    flex: 1 1 calc(100% - 60px);
+    padding-right: 0;
+  }
+
+  .pipeline-meta-actions {
+    flex: 1 1 100%;
+    justify-content: space-between;
+  }
+
+  .pipeline-updated {
+    font-size: 0.7rem;
+  }
+
+  .row-actions {
+    opacity: 1;
+  }
+}
 </style>

--- a/apps/ui/src/pages/paths.vue
+++ b/apps/ui/src/pages/paths.vue
@@ -364,4 +364,20 @@ const goAdvanced = () => {
   opacity: 0.4;
   cursor: not-allowed;
 }
+
+@media (max-width: 640px) {
+  .paths-content {
+    padding: 0 12px 96px;
+  }
+
+  .paths-header {
+    flex-wrap: wrap;
+  }
+
+  .ship-all-btn {
+    min-height: 48px;
+    position: sticky;
+    bottom: calc(72px + env(safe-area-inset-bottom));
+  }
+}
 </style>

--- a/apps/ui/src/pages/paths.vue
+++ b/apps/ui/src/pages/paths.vue
@@ -366,6 +366,11 @@ const goAdvanced = () => {
 }
 
 @media (max-width: 640px) {
+  .paths-page {
+    height: 100%;
+    min-height: 0;
+  }
+
   .paths-content {
     padding: 0 12px 96px;
   }

--- a/apps/ui/src/pages/plugins.vue
+++ b/apps/ui/src/pages/plugins.vue
@@ -1063,4 +1063,37 @@ const togglePlugin = async (packageName: string) => {
     border-left-color: var(--p-red-600);
   }
 }
+
+/* ─── Mobile: drawer becomes top strip, grids single column ─ */
+@media (max-width: 860px) {
+  .main-layout {
+    flex-direction: column;
+  }
+
+  .drawer {
+    width: 100%;
+    flex: 0 0 auto;
+    border-right: none;
+    border-bottom: 1px solid var(--p-surface-200);
+    max-height: 38vh;
+
+    :root.dark & {
+      border-bottom-color: var(--p-surface-700);
+    }
+  }
+
+  .pane-content {
+    padding: 12px;
+  }
+
+  .pane-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .nodes-grid,
+  .integrations-grid {
+    grid-template-columns: 1fr;
+  }
+}
 </style>

--- a/apps/ui/src/style/main.scss
+++ b/apps/ui/src/style/main.scss
@@ -281,6 +281,51 @@ $sizes: 12, 14, 16, 18, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64, 72, 80, 
   }
 }
 
+/* ─── Mobile baseline ─────────────────────────────────── */
+html,
+body {
+  overscroll-behavior-y: none;
+}
+
+img,
+video,
+canvas,
+svg {
+  max-width: 100%;
+}
+
+@media (max-width: 768px) {
+  .p-dialog {
+    max-width: 95vw !important;
+  }
+
+  .p-dialog-content {
+    max-height: 70vh;
+    overflow-y: auto;
+  }
+
+  .p-toast {
+    width: calc(100vw - 24px);
+    max-width: 400px;
+  }
+
+  /* ponytail: coarse-pointer floor only, per-component sizes win above 40px */
+  @media (pointer: coarse) {
+    .p-button,
+    button {
+      min-height: 40px;
+    }
+
+    .p-inputtext,
+    .p-select,
+    input,
+    select,
+    textarea {
+      font-size: 16px !important; /* prevents iOS zoom on focus */
+    }
+  }
+}
+
 /* Fix for PrimeVue v4 IconField / InputIcon positioning */
 .p-iconfield,
 .p-icon-field {

--- a/packages/core-node/src/handlers/auth.ts
+++ b/packages/core-node/src/handlers/auth.ts
@@ -14,6 +14,18 @@ export const registerAuthHandlers = (context: PipelabContext) => {
   const supabaseAvailable = isSupabaseAvailable();
   if (!supabaseAvailable) {
     logger().warn("[Auth] Supabase is not available. Auth handlers will not be functional.");
+    // Register the invoke channel even when cloud services are unavailable.
+    // Otherwise browser requests remain pending forever (for example, the
+    // upgrade dialog stays on "Loading plans...").
+    handle("auth:invoke", async (_, { send }) => {
+      return send({
+        type: "end",
+        data: {
+          type: "error",
+          ipcError: "Supabase is not configured; cloud functions are unavailable.",
+        },
+      });
+    });
     return;
   }
 


### PR DESCRIPTION
Mobile-ready UI, CSS-only, no new deps.

- Layout <=768px: sidebar becomes bottom tab bar (44px targets, safe-area inset), hides header/status/upgrade/Soon items
- Dashboard + Plugins <=860px: drawers stack on top (projects as horizontal chips, plugins max 38vh), pipeline rows wrap, search/actions full-width, grids single column
- Editor <=768px: toolbar wraps to icon-only buttons with full-width title row, node params drawer becomes 72dvh bottom sheet, logs sit above tab bar, animated ticker hidden
- Node cards full-width on mobile; Paths rows stack, source card hides timestamp, add-destination becomes bottom sheet, ship-all sticky above tab bar
- Global: dialog 95vw cap, toast full-width, coarse-pointer 40px floor + 16px inputs (no iOS zoom), viewport-fit=cover

Skipped: hamburger drawer, touch drag reorder. Not verified with build (no node_modules in worktree); style-only changes, braces checked.