### PR TITLE
Support Pipelab startup in development and production

### DIFF
--- a/.agents/skills/tailscale-preview/SKILL.md
+++ b/.agents/skills/tailscale-preview/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: tailscale-preview
+description: Serve the Pipelab UI and CLI dev servers for remote browser access over Tailscale.
+---
+
 # Tailscale Preview — serve the app for remote browser access
 
 Run the Pipelab UI + CLI dev servers so a remote browser (e.g. the developer's

--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ graph TD
 
 ---
 
-## 🛠️ Setup & Development
+## 🛠️ Start Pipelab
 
 ### 1. Prerequisites
 
-Tool versions are managed via **mise**. Check [`.mise.toml`](.mise.toml) for the current requirements.
+Tool versions are managed via **mise**. Check [`mise.toml`](mise.toml) for the current requirements (Node 24 and pnpm 10.33.0).
 
 ### 2. Environment Configuration
 
@@ -54,13 +54,15 @@ SUPABASE_ANON_KEY=your_key
 POSTHOG_API_KEY=your_key
 ```
 
+`SUPABASE_URL` and `SUPABASE_ANON_KEY` enable authentication. `POSTHOG_API_KEY` enables telemetry. The app still starts without them, with the related cloud features disabled.
+
 ### 3. Installation
 
 ```bash
 pnpm install
 ```
 
-### 4. Running Development Mode
+### 4. Development
 
 The fastest way to start the entire ecosystem is from the root:
 
@@ -69,7 +71,36 @@ pnpm dev
 ```
 
 > [!TIP]
-> This command uses **Turborepo** to start the UI dev server, the Electron process, and the CLI server concurrently.
+> This starts the UI dev server and Electron. Electron starts and manages the local CLI sidecar itself, so do not start `@pipelab/cli` separately for the desktop workflow.
+
+The Electron window opens after the UI is available on port 5173. Use `Ctrl+C` in the terminal to stop the development processes.
+
+### 5. Production package
+
+Create a runnable application bundle for the current operating system:
+
+```bash
+pnpm package
+```
+
+Create an installable distributable instead:
+
+```bash
+pnpm make
+```
+
+Both commands build the CLI bundle and include it with the desktop application as its production sidecar. Forge writes results to `apps/desktop/out/`; `package` creates an unpacked application bundle, while `make` creates the platform-specific installer/archive. Build on each target operating system for its native installer format.
+
+### Useful commands
+
+| Command | Purpose |
+| --- | --- |
+| `pnpm dev` | Start the desktop app in development mode. |
+| `pnpm build` | Build all workspace packages. |
+| `pnpm package` | Create a production desktop bundle for the current platform. |
+| `pnpm make` | Create a production installer/archive for the current platform. |
+| `pnpm test` | Run the workspace test suites. |
+| `pnpm typecheck` | Run TypeScript checks across the workspace. |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -4,11 +4,13 @@
   "license": "FSL-1.1-MIT",
   "scripts": {
     "build": "turbo build",
-    "dev": "turbo dev",
+    "dev": "turbo dev --filter=@pipelab/ui --filter=@pipelab/app",
     "lint": "turbo lint",
     "test": "turbo test",
     "typecheck": "turbo typecheck",
     "format": "turbo format",
+    "package": "pnpm --filter @pipelab/app package",
+    "make": "pnpm --filter @pipelab/app make",
     "changeset": "changeset",
     "supa:types": "supabase gen types typescript --project-id $SUPABASE_PROJECT_ID > packages/shared/src/database.types.ts"
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "FSL-1.1-MIT",
   "scripts": {
     "build": "turbo build",
-    "dev": "turbo dev --filter=@pipelab/ui --filter=@pipelab/app",
+    "dev": "turbo dev",
     "lint": "turbo lint",
     "test": "turbo test",
     "typecheck": "turbo typecheck",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -63,7 +63,6 @@ export * from "./variables";
 export * from "./websocket.types";
 export * from "./path";
 export * from "./plugin-api";
-export * from "./pipelab-context";
 
 // 4. Configuration Sub-packages
 export * from "./config/projects-definition"; // <-- RE-ADDED

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -28,6 +28,7 @@
     "lint": "oxlint ."
   },
   "dependencies": {
+    "@pipelab/core-node": "workspace:*",
     "@pipelab/plugin-core": "workspace:*",
     "execa": "9.5.1"
   },

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -7,8 +7,8 @@ import {
   type ActionRunner,
   type ActionRunnerData,
   type Action,
-  PipelabContext,
 } from "@pipelab/plugin-core";
+import { PipelabContext as NodePipelabContext } from "@pipelab/core-node";
 import { execa } from "execa";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -204,7 +204,7 @@ process.exit(result.status ?? 0);`,
     // @ts-ignore - Mocking BrowserWindow
     browserWindow: undefined,
     abortSignal: new AbortController().signal,
-    context: new PipelabContext({
+    context: new NodePipelabContext({
       userDataPath: join(options.sandboxPath, "user-data"),
     }),
     // @ts-ignore - Mocking setMeta

--- a/plugins/plugin-construct/src/export-shared.ts
+++ b/plugins/plugin-construct/src/export-shared.ts
@@ -203,7 +203,9 @@ export const exportc3p = async <ACTION extends Action>(
     );
   }
 
-  const require = createRequire(import.meta.url);
+  // Electron's Vite main-process bundle is CommonJS, where import.meta.url is
+  // undefined. Use an absolute anchor that works in both ESM and CommonJS.
+  const require = createRequire(join(process.cwd(), "package.json"));
   const playwrightModule = require(join(playwrightPkgPath, "index.js"));
   const playwright = playwrightModule.default || playwrightModule;
 

--- a/plugins/plugin-core/src/pipelab.ts
+++ b/plugins/plugin-core/src/pipelab.ts
@@ -9,6 +9,9 @@ import type {
   ExtractInputsFromEvent,
   ExtractInputsFromExpression,
 } from "@pipelab/shared";
+import type { PipelabContext } from "@pipelab/core-node";
+
+export type { PipelabContext } from "@pipelab/core-node";
 
 export * from "@pipelab/shared";
 import {

--- a/plugins/plugin-filesystem/src/open.ts
+++ b/plugins/plugin-filesystem/src/open.ts
@@ -1,9 +1,6 @@
 import { exec } from "node:child_process";
 import { platform } from "node:os";
-import { createRequire } from "node:module";
 import { createAction, createActionRunner, createPathParam } from "@pipelab/plugin-core";
-
-const require = createRequire(import.meta.url);
 // import displayString from './displayStringRun.lua?raw'
 
 export const ID = "fs:open-in-explorer";

--- a/plugins/plugin-itch/src/ensure.ts
+++ b/plugins/plugin-itch/src/ensure.ts
@@ -1,7 +1,8 @@
 import { join } from "node:path";
 import { access, mkdir, chmod, rm } from "node:fs/promises";
 import { constants } from "node:fs";
-import { downloadFile, extractZip, PipelabContext } from "@pipelab/plugin-core";
+import { downloadFile, extractZip } from "@pipelab/plugin-core";
+import type { PipelabContext } from "@pipelab/plugin-core";
 
 /**
  * Installs itch.io butler CLI if not already present.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -738,6 +738,9 @@ importers:
 
   packages/test-utils:
     dependencies:
+      '@pipelab/core-node':
+        specifier: workspace:*
+        version: file:packages/core-node(typescript@5.9.3)
       '@pipelab/plugin-core':
         specifier: workspace:*
         version: file:plugins/plugin-core(typescript@5.9.3)


### PR DESCRIPTION
## Summary
- start development with Vite and Electron, with Electron managing the local CLI sidecar
- bundle the CLI, UI, and assets for production desktop packaging
- stage deployed workspace dependencies safely for Electron Forge
- document development, packaging, environment variables, and startup commands

## Verification
- `pnpm --filter @pipelab/ui build`
- `pnpm --filter @pipelab/cli build`
- production CLI HTTP smoke test against the bundled UI
- `pnpm dev` reached Vite readiness and launched Electron
- `mise exec node@24 -- npm exec --yes --package=pnpm@10.33.0 -- pnpm package` completed and produced `apps/desktop/out/PipelabBeta-linux-x64`
- `git diff --check`

The repository's pinned toolchain is Node 24 and pnpm 10.33.0; packaging should be run through that toolchain.
